### PR TITLE
Make the URL optional when loading a page.

### DIFF
--- a/TOWebViewController/TOWebViewController.h
+++ b/TOWebViewController/TOWebViewController.h
@@ -37,6 +37,9 @@
 /* Show the loading progress bar (default YES) */
 @property (nonatomic,assign)    BOOL showLoadingBar;
 
+/* Show the URL while loading the page, i.e. before the page's <title> tag is available (default YES) */
+@property (nonatomic,assign)    BOOL showUrlWhileLoading;
+
 /* Tint colour for the loading progress bar. Default colour is iOS system blue. */
 @property (nonatomic,copy)      UIColor *loadingBarTintColor;
 

--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -260,6 +260,7 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
     _buttonSpacing = (IPAD == NO) ? NAVIGATION_BUTTON_SPACING : NAVIGATION_BUTTON_SPACING_IPAD;
     _buttonWidth = NAVIGATION_BUTTON_WIDTH;
     _showLoadingBar = YES;
+    _showUrlWhileLoading = YES;
     
     //Set the initial default style as full screen (But this can be easily overwritten)
     self.modalPresentationStyle = UIModalPresentationFullScreen;
@@ -1025,10 +1026,12 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
         [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:YES];
         
         //set the title to the URL until we load the page properly
-        NSString *url = [self.url absoluteString];
-        url = [url stringByReplacingOccurrencesOfString:@"http://" withString:@""];
-        url = [url stringByReplacingOccurrencesOfString:@"https://" withString:@""];
-        self.title = url;
+        if (self.showUrlWhileLoading) {
+            NSString *url = [self.url absoluteString];
+            url = [url stringByReplacingOccurrencesOfString:@"http://" withString:@""];
+            url = [url stringByReplacingOccurrencesOfString:@"https://" withString:@""];
+            self.title = url;
+        } 
         
         if (self.reloadStopButton)
             [self.reloadStopButton setImage:self.stopIcon forState:UIControlStateNormal];


### PR DESCRIPTION
Added a showUrlWhileLoading BOOL property to prevent showing the URL while the page is loading.

I'm building an app where the initial URL is always redirected to something else (kind of like clicking on a bit.ly link). It is desirable to hide the initial URL in this scenario, since it is never the final URL.
