### PR TITLE
Update button spacing default

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -58,7 +58,7 @@
 /* Navigation Bar Properties */
 #define NAVIGATION_BUTTON_WIDTH             31
 #define NAVIGATION_BUTTON_SIZE              CGSizeMake(31,31)
-#define NAVIGATION_BUTTON_SPACING           60
+#define NAVIGATION_BUTTON_SPACING           58
 #define NAVIGATION_BUTTON_SPACING_IPAD      20
 #define NAVIGATION_BAR_HEIGHT               (MINIMAL_UI ? 64.0f : 44.0f)
 #define NAVIGATION_TOGGLE_ANIM_TIME         0.3


### PR DESCRIPTION
This is more of an aesthetic preference but with the new default, it seems more inline with Safari

Before
![ios simulator screen shot may 27 2014 9 15 12 am](https://cloud.githubusercontent.com/assets/4723115/3094247/3035ed2c-e5ba-11e3-8647-223dd5209487.png)

After
![ios simulator screen shot may 27 2014 9 13 27 am](https://cloud.githubusercontent.com/assets/4723115/3094249/35503ab0-e5ba-11e3-9663-228a62e2b8d9.png)

Safari
![ios simulator screen shot may 27 2014 9 13 36 am](https://cloud.githubusercontent.com/assets/4723115/3094251/38470866-e5ba-11e3-806b-e2e2752b1b84.png)
