### PR TITLE
Set hideToolbarOnClose and hideNavBarOnClose once

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -410,6 +410,11 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
 {
     [super viewDidLoad];
     
+    if (self.navigationController) {
+        self.hideToolbarOnClose = self.navigationController.toolbarHidden;
+        self.hideNavBarOnClose  = self.navigationBar.hidden;
+    }
+    
     //remove the shadow that lines the bottom of the webview
     if (MINIMAL_UI == NO) {
         for (UIView *view in self.webView.scrollView.subviews) {
@@ -457,9 +462,6 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
     
     //see if we need to show the toolbar
     if (self.navigationController) {
-        self.hideToolbarOnClose = self.navigationController.toolbarHidden;
-        self.hideNavBarOnClose  = self.navigationBar.hidden;
-        
         if (IPAD == NO) { //iPhone
             if (self.beingPresentedModally == NO) { //being pushed onto a pre-existing stack, so
                 [self.navigationController setToolbarHidden:NO animated:animated];


### PR DESCRIPTION
When a UIActivity presents a UIViewController,
such as UIActivityTypeMail, 
upon return viewWillAppear: will be called again
thus resetting hideToolbarOnClose and hideNavBarOnClose.
Avoid by setting them during viewDidLoad.
