### PR TITLE
Add activity type to safari and chrome activities

### DIFF
--- a/TOWebViewController/TOActivityChrome.h
+++ b/TOWebViewController/TOActivityChrome.h
@@ -22,6 +22,8 @@
 
 #import <UIKit/UIKit.h>
 
+extern NSString *const TOActivityTypeChrome;
+
 @interface TOActivityChrome : UIActivity
 
 @end

--- a/TOWebViewController/TOActivityChrome.m
+++ b/TOWebViewController/TOActivityChrome.m
@@ -22,6 +22,8 @@
 
 #import "TOActivityChrome.h"
 
+NSString *const TOActivityTypeChrome = @"au.com.timoliver.TOActivityTypeChrome";
+
 /* Detect if we're running iOS 7.0 or higher */
 #ifndef NSFoundationVersionNumber_iOS_6_1
 #define NSFoundationVersionNumber_iOS_6_1  993.00
@@ -43,6 +45,11 @@
 @implementation TOActivityChrome
 
 #pragma mark - Activity Display Properties -
+- (NSString *)activityType
+{
+    return TOActivityTypeChrome;
+}
+
 - (NSString *)activityTitle
 {
     return NSLocalizedStringFromTable(@"Chrome", @"TOWebViewControllerLocalizable", @"Open in Chrome Action");

--- a/TOWebViewController/TOActivitySafari.h
+++ b/TOWebViewController/TOActivitySafari.h
@@ -22,6 +22,8 @@
 
 #import <UIKit/UIKit.h>
 
+extern NSString *const TOActivityTypeSafari;
+
 @interface TOActivitySafari : UIActivity
 
 @end

--- a/TOWebViewController/TOActivitySafari.m
+++ b/TOWebViewController/TOActivitySafari.m
@@ -22,6 +22,8 @@
 
 #import "TOActivitySafari.h"
 
+NSString *const TOActivityTypeSafari = @"au.com.timoliver.TOActivityTypeSafari";
+
 /* Detect if we're running iOS 7.0 or higher */
 #ifndef NSFoundationVersionNumber_iOS_6_1
 #define NSFoundationVersionNumber_iOS_6_1  993.00
@@ -43,6 +45,11 @@
 @implementation TOActivitySafari
 
 #pragma mark - Activity Display Properties -
+- (NSString *)activityType
+{
+    return TOActivityTypeSafari;
+}
+
 - (NSString *)activityTitle
 {
     return NSLocalizedStringFromTable(@"Safari", @"TOWebViewControllerLocalizable", @"Open in Safari Action");


### PR DESCRIPTION
Activity types are necessary when different activities require different actions, in regards with UIActivityItemSource, UIActivityItemProvider and UIActivityViewControllerCompletionHandler.
