### PR TITLE
Make UIWebViewDelegate public

### DIFF
--- a/TOWebViewController/TOWebViewController.h
+++ b/TOWebViewController/TOWebViewController.h
@@ -26,7 +26,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface TOWebViewController : UIViewController
+@interface TOWebViewController : UIViewController <UIWebViewDelegate>
 
 /**
  Initializes a new `TOWebViewController` object with the specified URL.

--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -87,10 +87,10 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
 
 #pragma mark -
 #pragma mark Hidden Properties/Methods
-@interface TOWebViewController () <UIWebViewDelegate, UIActionSheetDelegate,
-                                    UIPopoverControllerDelegate,
-                                    MFMailComposeViewControllerDelegate,
-                                    MFMessageComposeViewControllerDelegate>
+@interface TOWebViewController () <UIActionSheetDelegate,
+                                   UIPopoverControllerDelegate,
+                                   MFMailComposeViewControllerDelegate,
+                                   MFMessageComposeViewControllerDelegate>
 {
     
     //The state of the UIWebView's scroll view before the rotation animation has started


### PR DESCRIPTION
Hi!
Please, let subclass to manage webView with `UIWebViewDelegate`. Move protocol `UIWebViewDelegate` to header file.
Thanks!
