### PR TITLE
avoid showing black block when the network is not reacheable

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -753,6 +753,8 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
 {
     self.loadingBarView.alpha = 0.0f;
+    webView.scrollView.scrollEnabled = NO;
+    webView.scrollView.bounces = NO;
     [self handleLoadRequestCompletion];
     [self refreshButtonsState];
 }


### PR DESCRIPTION
when the network is not reachable, the webview will show some black block(height seems sum of status, nav,bottombar) by scrolling down.
I just disable webview's two attributes:scrollEnable and bounce when it failed to load.
Maybe there is a better way.
