### PR TITLE
Hide the button toolbar when setting navigationButtonsHidden to YES

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -472,11 +472,11 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
     if (self.navigationController) {
         if (IPAD == NO) { //iPhone
             if (self.beingPresentedModally == NO) { //being pushed onto a pre-existing stack, so
-                [self.navigationController setToolbarHidden:NO animated:animated];
+                [self.navigationController setToolbarHidden:self.navigationButtonsHidden animated:animated];
                 [self.navigationController setNavigationBarHidden:NO animated:animated];
             }
             else { //Being presented modally, so control the
-                self.navigationController.toolbarHidden = NO;
+                self.navigationController.toolbarHidden = self.navigationButtonsHidden;
             }
         }
         else {


### PR DESCRIPTION
The comments of "navigationButtonsHidden" says "on iPhone, hides the bottom toolbar".

However, when I set navigationButtonsHidden to YES after creating an TOWebViewController, the buttons are hidden, but the bottom toolbar itself remains.

I changed the code based on my understanding, because I think "navigationButtonsHidden" is used to hide the entire bottom toolbar.

Please check it, thank you!
