### PR TITLE
Add new option showDonebutton.

### DIFF
--- a/TOWebViewController/TOWebViewController.h
+++ b/TOWebViewController/TOWebViewController.h
@@ -98,6 +98,13 @@
 @property (nonatomic,assign)    BOOL showActionButton;
 
 /**
+ Shows the Done button when presented modally. When tapped, it dismisses the view controller.
+
+ Default value is YES.
+ */
+@property (nonatomic,assign)    BOOL showDoneButton;
+
+/**
  When web pages are loaded, the view controller's title property will be set to the page's
  HTML title attribute.
  

--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -249,6 +249,7 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
 {
     //Direct ivar reference since we don't want to trigger their actions yet
     _showActionButton = YES;
+    _showDoneButton   = YES;
     _buttonSpacing    = (IPAD == NO) ? NAVIGATION_BUTTON_SPACING : NAVIGATION_BUTTON_SPACING_IPAD;
     _buttonWidth      = NAVIGATION_BUTTON_WIDTH;
     _showLoadingBar   = YES;
@@ -448,7 +449,7 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
         self.buttonsContainerView.tintColor = self.buttonTintColor;
     
     // Create the Done button
-    if (self.beingPresentedModally && !self.onTopOfNavigationControllerStack) {
+    if (self.showDoneButton && self.beingPresentedModally && !self.onTopOfNavigationControllerStack) {
         NSString *title = NSLocalizedStringFromTable(@"Done", @"TOWebViewControllerLocalizable", @"Modal Web View Controller Close");
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithTitle:title style:UIBarButtonItemStyleDone target:self action:@selector(doneButtonTapped:)];
         if (IPAD)


### PR DESCRIPTION
Hi,

first of all, thanks for this great library! I'd like to propose a new property:

This adds a new option called showDoneButton. It defaults to YES, so no
change in behaviour for old code using TOWebViewController.

If you set this property to NO, it will not add a done bar button item
when presented modally. So it's up to the user where to place a button to
dismiss the view controller.

Cheers,
plu
