### PR TITLE
Do not perform animation when reseting loading progress.

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -1110,7 +1110,7 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
 - (void)setLoadingProgress:(CGFloat)loadingProgress
 {
     // progress should be incremental only
-    if (loadingProgress > _loadingProgressState.loadingProgress || loadingProgress == 0)
+    if (loadingProgress > _loadingProgressState.loadingProgress)
     {
         _loadingProgressState.loadingProgress = loadingProgress;
         
@@ -1131,6 +1131,16 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
                     }];
                 }
             }];
+        }
+    }
+    else if (loadingProgress == 0)
+    {
+        _loadingProgressState.loadingProgress = loadingProgress;
+        if (self.showLoadingBar)
+        {
+            CGRect frame = self.loadingBarView.frame;
+            frame.origin.x = -CGRectGetWidth(self.loadingBarView.frame);
+            self.loadingBarView.frame = frame;
         }
     }
 }


### PR DESCRIPTION
Loading progress will flash from 100% to 0% when reseting loading progress with animation.
Handle loadingProgress == 0 separately with no animation.