### PR TITLE
Fix designated initializer and allow subclassing

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -224,7 +224,7 @@ static const float kAfterInteractiveMaxProgressValue    = 0.9f;
 
 - (instancetype)initWithURL:(NSURL *)url
 {
-    if (self = [self init])
+    if (self = [super init])
         _url = [self cleanURL:url];
     
     return self;


### PR DESCRIPTION
Because `-initWithURL:` is implemented by invoking `[self init]` instead of
calling up to `[super init]` and `-init` is not implemented here, it breaks
subclasses that choose for their designated initializer to be `-init`. When a
subclass that is designed to be initialized with a plain `-init` calls to super
to invoke `-initWithURL:`, `TOWebViewController` invokes `-init` on self causing
it to fallback into the subclass's implementation of `-init` causing an infinite
loop.