### PR TITLE
fix: change title string when showPageTitles==NO

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -865,7 +865,7 @@
         url = [url stringByReplacingOccurrencesOfString:@"https://" withString:@""];
         self.title = url;
     }
-    else {
+    else if (self.showPageTitles) {
         self.title = NSLocalizedStringFromTable(@"Loading...", @"TOWebViewControllerLocalizable", @"Laoding...");
     }
 }


### PR DESCRIPTION
I set `showPageTitles= NO`, but the strings of title bar on TOWebViewController changed the strings to "Loading..", and it has not been changed any more.

I fixed this. 
