### PR TITLE
 This method return a wrong BOOL value.

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -457,7 +457,7 @@
         return (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact);
     }
     
-    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
+    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
 }
 
 - (BOOL)beingPresentedModally


### PR DESCRIPTION
When this project run in iOS7 iPhone, the toolBar is on the
NavigationBar, just like run in iPad.
Because, this method returns a wrong BOOL value.