### PR TITLE
fix Installation with 'carthage' failed

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -64,7 +64,7 @@
                                    UIPopoverControllerDelegate,
                                    MFMailComposeViewControllerDelegate,
                                    MFMessageComposeViewControllerDelegate,
-                                   NJKWebViewProgressDelegate>
+                                   NJKWebViewProgressDelegate,CAAnimationDelegate>
 {
     
     //The state of the UIWebView's scroll view before the rotation animation has started


### PR DESCRIPTION
Semantic issue: Sending 'TOWebViewController *const __strong' to parameter of incompatible type 'id<CAAnimationDelegate> _Nullable'