### PR TITLE
Implement a 'didFailLoadWithError' block

### DIFF
--- a/TOWebViewController/TOWebViewController.h
+++ b/TOWebViewController/TOWebViewController.h
@@ -169,6 +169,11 @@
 @property (nonatomic,copy)      BOOL (^shouldStartLoadRequestHandler)(NSURLRequest *request, UIWebViewNavigationType navigationType);
 
 /**
+ An optional block that when set, will be triggered if the web view failed to load a frame.
+ */
+@property (nonatomic,copy)      void (^didFailLoadWithErrorRequestHandler)(NSError *error);
+
+/**
 An optional block that when set, will be triggered each time the web view has finished a load operation.
 */
 @property (nonatomic,copy)      void (^didFinishLoadHandler)(UIWebView *webView);

--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -794,6 +794,13 @@
     return shouldStart;
 }
 
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    //If a request handler has been set, check to see if we should go ahead
+    if (self.didFailLoadWithErrorRequestHandler)
+        return self.didFailLoadWithErrorRequestHandler(error);
+}
+
 - (void)webViewDidStartLoad:(UIWebView *)webView
 {
     //show that loading started in the status bar


### PR DESCRIPTION
If the web view failed to load a frame you get an Error object.

For example:

`Error Domain=NSURLErrorDomain Code=-1003 "A server with the specified hostname could not be found." UserInfo={NSUnderlyingError=0x6040004572b0 {Error Domain=kCFErrorDomainCFNetwork Code=-1003 "A server with the specified hostname could not be found." UserInfo={NSErrorFailingURLStringKey=https://asljfhasdfjlsaflkasf.com.de.com/, NSErrorFailingURLKey=https://asljfhasdfjlsaflkasf.com.de.com/, _kCFStreamErrorCodeKey=8, _kCFStreamErrorDomainKey=12, NSLocalizedDescription=A server with the specified hostname could not be found.}}, NSErrorFailingURLStringKey=https://asljfhasdfjlsaflkasf.com.de.com/, NSErrorFailingURLKey=https://asljfhasdfjlsaflkasf.com.de.com/, _kCFStreamErrorDomainKey=12, _kCFStreamErrorCodeKey=8, NSLocalizedDescription=A server with the specified hostname could not be found.`