### PR TITLE
Added CAAnimationDelegate to TOWebViewController interface

### DIFF
--- a/TOWebViewController/TOWebViewController.m
+++ b/TOWebViewController/TOWebViewController.m
@@ -62,6 +62,7 @@
 #pragma mark Hidden Properties/Methods
 @interface TOWebViewController () <UIActionSheetDelegate,
                                    UIPopoverControllerDelegate,
+                                   CAAnimationDelegate,
                                    MFMailComposeViewControllerDelegate,
                                    MFMessageComposeViewControllerDelegate,
                                    NJKWebViewProgressDelegate,CAAnimationDelegate>


### PR DESCRIPTION
Added CAAnimationDelegate to TOWebViewController interface to so that
the warning in #112 won’t appear

Tested in Xcode 9.2